### PR TITLE
Produktionsplan

### DIFF
--- a/ibsys2Produktionsplanung/src/pages/Produktionsplanung.tsx
+++ b/ibsys2Produktionsplanung/src/pages/Produktionsplanung.tsx
@@ -373,7 +373,7 @@ export function Produktionsplanung() {
                                             min={0}
                                             value={vertriebswunsch["konventionalStrafe"][key]}
                                             onChange={(e) => {
-                                                // removes leading 0
+                                                // Removes leading 0
                                                 // @ts-ignore
                                                 e.target.value = Math.abs(e.target.value);
                                                 const input = e.target.value.replace(",", ".");

--- a/ibsys2Produktionsplanung/src/pages/Produktionsplanung.tsx
+++ b/ibsys2Produktionsplanung/src/pages/Produktionsplanung.tsx
@@ -376,7 +376,8 @@ export function Produktionsplanung() {
                                                 // removes leading 0
                                                 // @ts-ignore
                                                 e.target.value = Math.abs(e.target.value);
-                                                const value = Math.max(0, parseInt(e.target.value) || 0);
+                                                const input = e.target.value.replace(",", ".");
+                                                const value = Math.max(0, parseFloat(input) || 0);
                                                 setVertriebswunsch((prev) => {
                                                     return {
                                                         ...prev,


### PR DESCRIPTION
Die Konventionalstrafe sollte auch in Gleitkommazahl angegeben werden können